### PR TITLE
add header Accept-Language :en-US  to browser 

### DIFF
--- a/twitter_scraper.py
+++ b/twitter_scraper.py
@@ -9,7 +9,7 @@ session = HTMLSession()
 
 browser = mechanicalsoup.StatefulBrowser()
 browser.addheaders = [('User-agent', 'Firefox')]
-browser.session.headers.update('Accept-Language','en-US')
+browser.session.headers.update({'Accept-Language':'en-US'})
 def get_tweets(query, pages=25):
     """Gets tweets for a given user, via the Twitter frontend API."""
 

--- a/twitter_scraper.py
+++ b/twitter_scraper.py
@@ -9,7 +9,7 @@ session = HTMLSession()
 
 browser = mechanicalsoup.StatefulBrowser()
 browser.addheaders = [('User-agent', 'Firefox')]
-
+browser.session.headers.update('Accept-Language','en-US')
 def get_tweets(query, pages=25):
     """Gets tweets for a given user, via the Twitter frontend API."""
 


### PR DESCRIPTION
In one region (I tested Japan) an error occurred when extracting "favorite" and so on in read_profile, so I set "en-US" in the header as well as gen_tweets.

I think  "Accept-Language" may also need in the subsequent function additions to adapt other region.