### PR TITLE
Fixed bug README.rst -> README.md in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ REQUIRED = [
 here = os.path.abspath(os.path.dirname(__file__))
 
 # Import the README and use it as the long-description.
-# Note: this will only work if 'README.rst' is present in your MANIFEST.in file!
-with io.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
+# Note: this will only work if 'README.md' is present in your MANIFEST.in file!
+with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = '\n' + f.read()
 
 


### PR DESCRIPTION
Fixed bug at source code!!

Fixed **setup.py README.rst** to **README.md**.
And fixed annotation to related problem.

README file has changed to **.md** so, It must be change to **.rst** to **.md** for installing packages!!