### PR TITLE
Error getting profile.

### DIFF
--- a/twitter_scraper/modules/profile.py
+++ b/twitter_scraper/modules/profile.py
@@ -36,6 +36,9 @@ class Profile:
         except AttributeError:
             raise ValueError(
                     f'Oops! Either "@{self.username}" does not exist or is private.')
+        except IndexError:
+            pass
+
 
         # parse birthday
         try:


### PR DESCRIPTION
Some existing profiles simply do not have a location, and in these cases the library throws an error. For example this https://twitter.com/just_dylen