### PR TITLE
fix video_id substring not found

### DIFF
--- a/twitter_scraper/modules/tweets.py
+++ b/twitter_scraper/modules/tweets.py
@@ -103,7 +103,8 @@ def get_tweets(query, pages=25):
                     for style in styles:
                         if style.startswith('background'):
                             tmp = style.split('/')[-1]
-                            video_id = tmp[:tmp.index('.jpg')]
+                            video_id = tmp[:tmp.index('.jpg')] if 'jpg' in tmp \
+                                else tmp[:tmp.index('.png')] if 'png' in tmp else None
                             videos.append({'id': video_id})
 
                 tweets.append({


### PR DESCRIPTION
Error:
```  
File "...", line 36, in get_posts
    for post in get_tweets(page.username, pages=self.pages):
  File ".../lib/python3.6/site-packages/twitter_scraper.py", line 78, in get_tweets
    yield from gen_tweets(pages)
  File "..../lib/python3.6/site-packages/twitter_scraper.py", line 57, in gen_tweets
    video_id = tmp[:tmp.index('.jpg')]
ValueError: substring not found
```
Debugging:
```
ipdb> tmp
"EMzUkfMXYAIAAox.png')"
```
--> Add 'png' as a valid image format.
