### PR TITLE
Fix http replacing problem via regex

### DIFF
--- a/twitter_scraper/modules/tweets.py
+++ b/twitter_scraper/modules/tweets.py
@@ -124,9 +124,8 @@ def get_tweets(query, pages=25):
             last_tweet = html.find('.stream-item')[-1].attrs['data-item-id']
 
             for tweet in tweets:
-                if tweet:
-                    tweet['text'] = re.sub(r'\Shttp', ' http', tweet['text'], 1)
-                    tweet['text'] = re.sub(r'\Spic\.twitter', ' pic.twitter', tweet['text'], 1)
+                    tweet['text'] = re.sub(r'(\S)http', '\g<1> http', tweet['text'], 1)
+                    tweet['text'] = re.sub(r'(\S)pic\.twitter', '\g<1> pic.twitter', tweet['text'], 1)
                     yield tweet
 
             r = session.get(url, params={'max_position': last_tweet}, headers=headers)


### PR DESCRIPTION
As descripted on #102 if an url follows a word, currently we are replacing the last character with white space. 

Just changed this method, now keeping last character and adding a white space last character and 'http'