### PR TITLE
Fix search for video_id extension

### DIFF
--- a/twitter_scraper/modules/tweets.py
+++ b/twitter_scraper/modules/tweets.py
@@ -103,8 +103,8 @@ def get_tweets(query, pages=25):
                     for style in styles:
                         if style.startswith('background'):
                             tmp = style.split('/')[-1]
-                            video_id = tmp[:tmp.index('.jpg')] if 'jpg' in tmp \
-                                else tmp[:tmp.index('.png')] if 'png' in tmp else None
+                            video_id = tmp[:tmp.index('.jpg')] if '.jpg' in tmp \
+                                else tmp[:tmp.index('.png')] if '.png' in tmp else None
                             videos.append({'id': video_id})
 
                 tweets.append({


### PR DESCRIPTION
If we're unlucky the random video_id may contain the letters "jpg"
without containing the string ".jpg", causing this traceback:
```
  Traceback (most recent call last):
    File "./twitter-to-rss.py", line 41, in <module>
      for (n, tweet) in enumerate(twitter_scraper.get_tweets(user, pages=10)):
    File "/usr/local/lib/python3.7/site-packages/twitter_scraper/modules/tweets.py", line 134, in get_tweets
      yield from gen_tweets(pages)
    File "/usr/local/lib/python3.7/site-packages/twitter_scraper/modules/tweets.py", line 106, in gen_tweets
      video_id = tmp[:tmp.index('.jpg')] if 'jpg' in tmp \
  ValueError: substring not found
```