### PR TITLE
Add tweet's username and URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,8 @@ It returns a dictionary for each tweet. Keys of the dictionary;
 | Key       | Type       | Description                                                      |
 |-----------|------------|------------------------------------------------------------------|
 | tweetId   | string     | Tweet's identifier, visit twitter.com/USERNAME/ID to view tweet. |
-| username  | string     | Tweet's username
-       |
-| tweetUrl  | string     | Tweet's URL
-       |
+| username  | string     | Tweet's username                                                 |
+| tweetUrl  | string     | Tweet's URL                                                      |
 | isRetweet | boolean    | True if it is a retweet, False othercase                         |
 | time      | datetime   | Published date of tweet                                          |
 | text      | string     | Content of tweet                                                 |

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ It returns a dictionary for each tweet. Keys of the dictionary;
 | Key       | Type       | Description                                                      |
 |-----------|------------|------------------------------------------------------------------|
 | tweetId   | string     | Tweet's identifier, visit twitter.com/USERNAME/ID to view tweet. |
+| username  | string     | Tweet's username
+       |
+| tweetUrl  | string     | Tweet's URL
+       |
 | isRetweet | boolean    | True if it is a retweet, False othercase                         |
 | time      | datetime   | Published date of tweet                                          |
 | text      | string     | Content of tweet                                                 |

--- a/twitter_scraper/modules/tweets.py
+++ b/twitter_scraper/modules/tweets.py
@@ -46,7 +46,7 @@ def get_tweets(query, pages=25):
             comma = ","
             dot = "."
             tweets = []
-            for tweet in html.find('.stream-item'):
+            for tweet, profile in zip(html.find('.stream-item'), html.find('.js-profile-popup-actionable')):
                 # 10~11 html elements have `.stream-item` class and also their `data-item-type` is `tweet`
                 # but their content doesn't look like a tweet's content
                 try:
@@ -55,6 +55,10 @@ def get_tweets(query, pages=25):
                     continue
 
                 tweet_id = tweet.attrs['data-item-id']
+
+                tweet_url = profile.attrs['data-permalink-path']
+
+                username = profile.attrs['data-screen-name']
 
                 time = datetime.fromtimestamp(int(tweet.find('._timestamp')[0].attrs['data-time-ms']) / 1000.0)
 
@@ -109,6 +113,8 @@ def get_tweets(query, pages=25):
 
                 tweets.append({
                     'tweetId': tweet_id,
+                    'tweet_url': tweet_url,
+                    'username': username,
                     'isRetweet': is_retweet,
                     'time': time,
                     'text': text,

--- a/twitter_scraper/modules/tweets.py
+++ b/twitter_scraper/modules/tweets.py
@@ -113,7 +113,7 @@ def get_tweets(query, pages=25):
 
                 tweets.append({
                     'tweetId': tweet_id,
-                    'tweet_url': tweet_url,
+                    'tweetUrl': tweet_url,
                     'username': username,
                     'isRetweet': is_retweet,
                     'time': time,


### PR DESCRIPTION
Consider this scenario:

Sometime people may want to search for tweets by hashtag, and then do some analysis to the owner of these tweets, this feature helps people identify the owners.

Thanks.