### PR TITLE
fixed pagination bug not extracting tweets after first page

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Thanks to the following people who have contributed to this project:
 * @bisguzar (maintainer)
 * @lionking6792
 * @ozanbayram
-
+* @xeliot
 
 
 ## Contact

--- a/twitter_scraper/modules/tweets.py
+++ b/twitter_scraper/modules/tweets.py
@@ -29,12 +29,13 @@ def get_tweets(query, pages=25):
     }
 
     def gen_tweets(pages):
-        r = session.get(url, headers=headers)
+        r = session.get(url + '&max_position', headers=headers)
 
         while pages > 0:
             try:
+                r_json = r.json()
                 html = HTML(
-                    html=r.json()["items_html"], url="bunk", default_encoding="utf-8"
+                    html=r_json["items_html"], url="bunk", default_encoding="utf-8"
                 )
             except KeyError:
                 raise ValueError(
@@ -164,7 +165,7 @@ def get_tweets(query, pages=25):
                 )
                 yield tweet
 
-            r = session.get(url, params={"max_position": last_tweet}, headers=headers)
+            r = session.get(url, params={"max_position": r_json['min_position']}, headers=headers)
             pages += -1
 
     yield from gen_tweets(pages)

--- a/twitter_scraper/modules/tweets.py
+++ b/twitter_scraper/modules/tweets.py
@@ -29,13 +29,13 @@ def get_tweets(query, pages=25):
     }
 
     def gen_tweets(pages):
-        r = session.get(url + '&max_position', headers=headers)
+        request = session.get(url + '&max_position', headers=headers)
 
         while pages > 0:
             try:
-                r_json = r.json()
+                json_response = request.json()
                 html = HTML(
-                    html=r_json["items_html"], url="bunk", default_encoding="utf-8"
+                    html=json_response["items_html"], url="bunk", default_encoding="utf-8"
                 )
             except KeyError:
                 raise ValueError(
@@ -165,7 +165,7 @@ def get_tweets(query, pages=25):
                 )
                 yield tweet
 
-            r = session.get(url, params={"max_position": r_json['min_position']}, headers=headers)
+            request = session.get(url, params={"max_position": json_response['min_position']}, headers=headers)
             pages += -1
 
     yield from gen_tweets(pages)


### PR DESCRIPTION
Fixes issue (#101)

Brief summary of how I fixed it by modifying `tweets.py`:

Change `r = session.get(url, headers=headers)` to `r = session.get(url+'&max_position', headers=headers)`. This allows response json to return `min_position` parameter which will then be used as the `max_position` parameter in the next `session.get`

`r_json = r.json()`

Change `r = session.get(url, params={'max_position': last_tweet}, headers=headers)` to `r = session.get(url, params={'max_position': r_json['min_position']}, headers=headers)`. 

This gets rid of twitter pages repeating on search query.