### PR TITLE
Fixed ripping of "banner_photo"

### DIFF
--- a/twitter_scraper/modules/profile.py
+++ b/twitter_scraper/modules/profile.py
@@ -75,7 +75,7 @@ class Profile:
         self.profile_photo = html.find(".ProfileAvatar-image")[0].attrs["src"]
 
         try:
-            self.banner_photo = html.find(".ProfileCanopy-headerBg img")[0].attrs["src"]
+            self.banner_photo = html.find(".css-9pa8cd img")[0].attrs["src"].replace("600x200", "1080x360")
         except KeyError:
             self.banner_photo = None
 


### PR DESCRIPTION
Changed the class the parser looks for and uses str.replace() in order to get the highest-quality image. Hope this gets merged as soon as possible; I'm using this in an RSS project and having access to banner images to use in Feedly would be awesome.